### PR TITLE
Hide the order message field in checkout and order ID on confirmation page

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1021,5 +1021,10 @@
         "privacy_policy": "Privacy Policy",
         "allow_category_tracking": "Allow [CATEGORY_NAME] tracking",
         "disallow_category_tracking": "Disallow [CATEGORY_NAME] tracking"
+    },
+    "optimized_checkout": {
+        "order_confirmation": {
+            "order_number_text": "Your order reference will be emailed to you shortly."
+        }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bigcommerce-cornerstone",
-      "version": "6.11.0",
+      "version": "6.12.0",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/stencil-utils": "6.15.1",

--- a/templates/pages/checkout.html
+++ b/templates/pages/checkout.html
@@ -1,5 +1,12 @@
 {{#partial "head"}}
 
+<style>
+    /* Hide the order comments field on checkout - it's being used to automatically store cart/customer info */
+    fieldset.form-fieldset[data-test="checkout-shipping-comments"] {
+        display: none !important;
+    }
+</style>
+
 {{{ checkout.checkout_head }}}
 {{{ stylesheet '/assets/css/optimized-checkout.css' }}}
 {{ getFontsCollection }}

--- a/templates/pages/order-confirmation.html
+++ b/templates/pages/order-confirmation.html
@@ -9,6 +9,14 @@
 
 {{{head.scripts}}}
 
+<style>
+    .custom-order-confirmation {
+        padding: 0 2rem;
+        margin: 2rem auto;
+        text-align: center;
+    }
+</style>
+
 {{/partial}}
 
 {{#partial "page"}}
@@ -26,6 +34,8 @@
         </h2>
     </div>
 </header>
+
+<div class="custom-order-confirmation">Your order refernce: #<span id="order-confirmation-prefix">TTXXXXXXXX</span></div>
 
 {{{ checkout.order_confirmation_content }}}
 


### PR DESCRIPTION
These changes are designed to work in combination with a Script Manager script, see: https://gist.github.com/petercossey/3f7d943ddab471aa216d940fc5b50f58

The JavaScript uses the cart ID to seed a custom order reference ID which is added to the order message. These theme changes hide the order message field from the checkout and they also remove any reference to the canonical order ID from the order confirmation page using the `optimized_checkout` language translation keys.